### PR TITLE
Add Option to select Branch for Plugin Installation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,14 @@ If you want to install a plugin from Kirby's official Plugins organisation (<htt
 kirby plugin:install cachebuster-plugin
 ```
 
+#### Branch Option
+
+You can pass a `--branch=dev`-Option to install the plugin form a specific branch. It defaults to the master branch.
+
+```
+kirby plugin:install getkirby-plugins/cachebuster-plugin --branch=dev
+```
+
 ### kirby plugin:update
 
 To update an existing plugin, you can use…
@@ -140,6 +148,14 @@ The shortcut for official plugins is working here as well:
 
 ```
 kirby plugin:update cachebuster-plugin
+```
+
+#### Branch Option
+
+You can pass a --branch=dev-Option to install the plugin form a specific branch. It defaults to the master branch.
+
+```
+kirby plugin:update getkirby-plugins/cachebuster-plugin --branch=dev
 ```
 
 ****

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ kirby plugin:install cachebuster-plugin
 
 #### Branch Option
 
-You can pass a `--branch=dev`-Option to install the plugin from a specific branch. It defaults to the master branch.
+You can pass a `--branch=awesomeBranch`-Option to install the plugin from a specific branch _(here awesomeBranch)_. It defaults to the master branch.
 
 ```
 kirby plugin:install getkirby-plugins/cachebuster-plugin --branch=dev
@@ -152,7 +152,7 @@ kirby plugin:update cachebuster-plugin
 
 #### Branch Option
 
-You can pass a --branch=dev-Option to install the plugin from a specific branch. It defaults to the master branch.
+You can pass a `--branch=awesomeBranch`-Option to install the plugin from a specific branch _(here awesomeBranch)_. It defaults to the master branch.
 
 ```
 kirby plugin:update getkirby-plugins/cachebuster-plugin --branch=dev

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ kirby plugin:install cachebuster-plugin
 
 #### Branch Option
 
-You can pass a `--branch=dev`-Option to install the plugin form a specific branch. It defaults to the master branch.
+You can pass a `--branch=dev`-Option to install the plugin from a specific branch. It defaults to the master branch.
 
 ```
 kirby plugin:install getkirby-plugins/cachebuster-plugin --branch=dev
@@ -152,7 +152,7 @@ kirby plugin:update cachebuster-plugin
 
 #### Branch Option
 
-You can pass a --branch=dev-Option to install the plugin form a specific branch. It defaults to the master branch.
+You can pass a --branch=dev-Option to install the plugin from a specific branch. It defaults to the master branch.
 
 ```
 kirby plugin:update getkirby-plugins/cachebuster-plugin --branch=dev

--- a/src/PluginCommand.php
+++ b/src/PluginCommand.php
@@ -58,7 +58,7 @@ class PluginCommand extends BaseCommand {
   protected function fetch() {
 
     $this->path = $this->input->getArgument('path');
-    $this->zip  = $this->download()->plugin($this->repo());
+    $this->zip  = $this->download()->plugin($this->repo(), $this->input->getOption('branch'));
     $this->tmp  = $this->dir() . '/' . f::name($this->zip);
 
     $this->filesystem([

--- a/src/PluginInstallCommand.php
+++ b/src/PluginInstallCommand.php
@@ -13,7 +13,8 @@ class PluginInstallCommand extends PluginCommand {
   protected function configure() {
     $this->setName('plugin:install')
          ->setDescription('Installs a new Kirby plugin from Github')
-         ->addArgument('path', InputArgument::REQUIRED, 'Github path');
+         ->addArgument('path', InputArgument::REQUIRED, 'Github path')
+         ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Branch (Master)', 'master');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/PluginUpdateCommand.php
+++ b/src/PluginUpdateCommand.php
@@ -13,7 +13,8 @@ class PluginUpdateCommand extends PluginCommand {
   protected function configure() {
     $this->setName('plugin:update')
          ->setDescription('Updates a Kirby plugin')
-         ->addArgument('path', InputArgument::REQUIRED, 'Github path');
+         ->addArgument('path', InputArgument::REQUIRED, 'Github path')
+         ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Branch (Master)', 'master');;
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/PluginUpdateCommand.php
+++ b/src/PluginUpdateCommand.php
@@ -14,7 +14,7 @@ class PluginUpdateCommand extends PluginCommand {
     $this->setName('plugin:update')
          ->setDescription('Updates a Kirby plugin')
          ->addArgument('path', InputArgument::REQUIRED, 'Github path')
-         ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Branch (Master)', 'master');;
+         ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Branch (Master)', 'master');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Util/Download.php
+++ b/src/Util/Download.php
@@ -60,9 +60,9 @@ class Download {
 
   }
 
-  public function plugin($repo) {
+  public function plugin($repo, $branch = 'master') {
 
-    $url  = $repo . '/archive/master.zip';
+    $url  = $repo . '/archive/' . $branch . '.zip';
     $file = getcwd() . '/kirby-plugin-' . md5(time() . uniqid()) . '.zip';
 
     $this->start($url, $file, 'Downloading plugin...');


### PR DESCRIPTION
Often when I want to install a new Plugin it has no `package.json` so I want to use the following workflow:
1. Fork Plugin project and add the `package.json`
2. Create a pull request
3. Install Plugin via CLI using my fork

---

It seems like Github wants you to create a new branch for Step 1 because then it's easier to create pull requests
