### PR TITLE
Proof of Concept: Show latest release in version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "php": ">=5.5.0",
         "ext-curl": "*",
         "ext-zip": "*",
-        "symfony/console": "*"
+        "symfony/console": "*",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "bin": [
         "kirby"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "autoload": {
         "psr-4": {
-            "Kirby\\Cli\\": "src/"
+            "Kirby\\Cli\\": "src/",
+            "Kirby\\Api\\": "src/Api"
         }
     },
     "require": {

--- a/src/Api/Github.php
+++ b/src/Api/Github.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kirby\Api;
+
+use GuzzleHttp\Client;
+
+class Github {
+
+  function __construct() {
+    $this->client = new Client([
+      'base_uri' => 'https://api.github.com'
+    ]);
+  }
+
+  public function getTag($owner, $repo, $version = 'latest' ) {
+    $response = $this->client->request('GET', 'repos/'. $owner .'/' . $repo . '/tags');
+
+    $repositories = json_decode($response->getBody(), true);
+
+    if ($version == 'latest') {
+      return $repositories[0];
+    } else {
+      foreach ($repositories as $tag) {
+        if ($tag['name'] == $version) {
+          return $tag;
+        }
+      }
+    }
+
+    return null;
+
+  }
+
+}

--- a/src/Command/Version.php
+++ b/src/Command/Version.php
@@ -7,7 +7,7 @@ use Panel;
 use RuntimeException;
 use Kirby;
 use Kirby\Cli\Command;
-use GuzzleHttp\Client;
+use Kirby\Api\Github;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -15,14 +15,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Version extends Command {
 
-  protected $client;
-
   function __construct() {
     parent::__construct();
-
-    $this->client = new Client([
-      'base_uri' => 'https://api.github.com'
-    ]);
+    $this->client = new Github();
   }
 
   protected function configure() {
@@ -31,8 +26,7 @@ class Version extends Command {
   }
 
   protected function getLatestRelease($repo) {
-    $response = $this->client->request('GET', 'repos/getkirby/' . $repo . '/tags');
-    return json_decode($response->getBody(), true)[0]['name'];
+    return $this->client->getTag('getkirby', $repo)['name'];
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/Version.php
+++ b/src/Command/Version.php
@@ -7,6 +7,7 @@ use Panel;
 use RuntimeException;
 use Kirby;
 use Kirby\Cli\Command;
+use GuzzleHttp\Client;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -14,9 +15,24 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Version extends Command {
 
+  protected $client;
+
+  function __construct() {
+    parent::__construct();
+
+    $this->client = new Client([
+      'base_uri' => 'https://api.github.com'
+    ]);
+  }
+
   protected function configure() {
     $this->setName('version')
          ->setDescription('Prints the current versions of the core, the toolkit and the panel of your installation');
+  }
+
+  protected function getLatestRelease($repo) {
+    $response = $this->client->request('GET', 'repos/getkirby/' . $repo . '/tags');
+    return json_decode($response->getBody(), true)[0]['name'];
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
@@ -28,8 +44,8 @@ class Version extends Command {
     // bootstrap the core
     $this->bootstrap();
 
-    $output->writeln("<info>Core:\t\t" . kirby::version() . "</info>");
-    $output->writeln("<info>Toolkit:\t" . toolkit::version() . "</info>");
+    $output->writeln("<info>Core:\t\t" . kirby::version() . "\t(latest: " . $this->getLatestRelease('kirby') . ")</info>");
+    $output->writeln("<info>Toolkit:\t" . toolkit::version() . "\t(latest: " . $this->getLatestRelease('toolkit') . ")</info>");
 
     // also check for the panel version, if it is installed
     if(is_dir($this->dir() . '/panel')) {
@@ -41,7 +57,7 @@ class Version extends Command {
       // bootstrap the panel
       require $this->dir() . '/panel/app/bootstrap.php';
 
-      $output->writeln("<info>Panel:\t\t" . panel::version() . "</info>");
+      $output->writeln("<info>Panel:\t\t" . panel::version() . "\t(latest: " . $this->getLatestRelease('panel') . ")</info>");
 
     }
 


### PR DESCRIPTION
Uses the Github API to show the latest remote version

```
~ kirby version
Core:       2.3.2   (latest: 2.3.2)
Toolkit:    2.3.2   (latest: 2.3.2)
Panel:      2.3.2   (latest: 2.3.2)
```
